### PR TITLE
[auth] Sign in only once

### DIFF
--- a/src/firebase-auth.ts
+++ b/src/firebase-auth.ts
@@ -4,32 +4,33 @@ import 'firebase/auth';
 export type AppUser = {
   readonly displayName: string;
   readonly email: string;
-  readonly token: string;
+  readonly idToken: string;
+  readonly accessToken: string;
 };
 
 /**
  * Returns the promise of an app user from the given raw firebase user.
  *
  * @param firebaseUser a raw firebase user or null.
+ * @param accessToken access token of the user.
  * @return the promise of an app user or null if there is no such user..
  */
-export async function toAppUser(firebaseUser: firebase.User | null): Promise<AppUser | null> {
-  if (firebaseUser == null) {
+export async function toAppUser(
+  firebaseUser: firebase.User | null,
+  accessToken: string | null
+): Promise<AppUser | null> {
+  if (firebaseUser == null || accessToken == null) {
     return null;
   }
   const { displayName, email } = firebaseUser;
   if (typeof displayName !== 'string' || typeof email !== 'string') {
     throw new Error('Bad user!');
   }
-  const token: string = await firebaseUser.getIdToken(true);
-  return { displayName, email, token };
+  const idToken: string = await firebaseUser.getIdToken(true);
+  return { displayName, email, idToken, accessToken };
 }
 
 let appUser: AppUser | null = null;
-
-firebase.auth().onAuthStateChanged(async user => {
-  appUser = await toAppUser(user);
-});
 
 export const hasUser = (): boolean => appUser != null;
 

--- a/src/gapi.ts
+++ b/src/gapi.ts
@@ -14,7 +14,7 @@ const DISCOVERY_DOCS = ['https://sheets.googleapis.com/$discovery/rest?version=v
 export const SCOPES = 'https://www.googleapis.com/auth/spreadsheets.readonly';
 
 /** Initializes the API client library and sets up sign-in state listeners. */
-async function initializeClient(onLoad: () => void) {
+async function initializeClient() {
   try {
     await gapi.client.init({
       apiKey: API_KEY,
@@ -26,16 +26,15 @@ async function initializeClient(onLoad: () => void) {
     // eslint-disable-next-line no-alert
     alert(JSON.stringify(error, null, 2));
   }
-  onLoad();
 }
 
-export const handleClientLoad = (onLoad: () => void): void =>
-  gapi.load('client:auth2', () => initializeClient(onLoad));
-
-// @ts-ignore
-export const signIn = (): Promise<void> => gapi.auth2.getAuthInstance().signIn();
-// @ts-ignore
-export const isSignedIn = (): boolean => gapi.auth2.getAuthInstance().isSignedIn.get();
+export const handleClientLoad = (accessToken: string, onLoad: () => void): void =>
+  gapi.load('client:auth2', async () => {
+    await initializeClient();
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    gapi.client.setToken({ access_token: accessToken });
+    onLoad();
+  });
 
 export const getSheetData = async (spreadsheetId: string, range: string): Promise<SheetData> => {
   // @ts-ignore


### PR DESCRIPTION
We use `gapi.client.setToken({ access_token: accessToken });` to set the token from firebase to gapi. We can now avoid sign in twice now!