### PR TITLE
Custom order/filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "lint": "eslint . --ext .ts --ext .tsx",
-    "format": "prettier --write '**/*.{ts,tsx,css,html}'",
-    "format:check": "prettier --check '**/*.{ts,tsx,css,html}'",
+    "format": "prettier --write **/*.{ts,tsx,css,html}",
+    "format:check": "prettier --check **/*.{ts,tsx,css,html}",
     "deploy": "yarn build && firebase deploy"
   },
   "eslintConfig": {

--- a/src/CustomOrderMenu.tsx
+++ b/src/CustomOrderMenu.tsx
@@ -1,0 +1,53 @@
+import { Button, ButtonGroup, Grid, TextField } from '@material-ui/core';
+import { Alert } from '@material-ui/lab';
+import { useState } from 'react';
+
+type Props = {
+  readonly contentLength: number;
+  readonly setCustomOrder: (order: number[]) => void;
+};
+
+export default function CustomOrderMenu({ contentLength, setCustomOrder }: Props): JSX.Element {
+  const [errorMsg, setErrorMsg] = useState('');
+  const [currentOrder, setCurrentOrder] = useState('');
+
+  const updateOrder = (orderStr: string) => {
+    const orderArr = orderStr.split(',').map((num) => Number(num));
+    if (orderArr.some((num) => isNaN(num) || num <= 0 || num > contentLength)) {
+      setErrorMsg('Custom Order: bad string or out of bounds');
+    } else if (orderArr.length !== new Set(orderArr).size) {
+      setErrorMsg('Custom Order: contains duplicates');
+    } else {
+      setErrorMsg('');
+      setCustomOrder(orderArr.map((num) => num - 1));
+    }
+  };
+
+  return (
+    <div>
+      {errorMsg && <Alert severity="error">{errorMsg}</Alert>}
+      <Grid container alignItems="center">
+        <TextField
+          label="Custom Order"
+          placeholder="1,5,2,3,88,6"
+          value={currentOrder}
+          onChange={(event) => setCurrentOrder(event.currentTarget.value)}
+        />
+        <ButtonGroup disableElevation variant="contained">
+          <Button color="primary" onClick={() => updateOrder(currentOrder)}>
+            Apply
+          </Button>
+          <Button
+            color="primary"
+            onClick={() => {
+              setErrorMsg('');
+              setCustomOrder([]);
+            }}
+          >
+            Reset
+          </Button>
+        </ButtonGroup>
+      </Grid>
+    </div>
+  );
+}

--- a/src/ReviewApplicationPanel.tsx
+++ b/src/ReviewApplicationPanel.tsx
@@ -43,22 +43,20 @@ export default function ReviewApplicationPanel({
   const [customOrder, setCustomOrder] = useState<number[]>([]);
   const effectiveOrder = customOrder.length ? customOrder : defaultOrder;
 
-  const getIndex = (id: number) => {
-    return effectiveOrder.findIndex(num => num === id);
-  }
+  const getIndex = (id: number) => effectiveOrder.findIndex((num) => num === id);
 
   const previous = () => {
     const index = getIndex(candidateId);
-    if(index >= 0) {
+    if (index >= 0) {
       updateCandidateId(effectiveOrder[index - 1]);
     }
-  }
+  };
   const next = () => {
     const index = getIndex(candidateId);
-    if(index >= 0) {
+    if (index >= 0) {
       updateCandidateId(effectiveOrder[index + 1]);
     }
-  }
+  };
   return (
     <div className={className}>
       <div className={styles.Section}>

--- a/src/ReviewApplicationPanel.tsx
+++ b/src/ReviewApplicationPanel.tsx
@@ -4,9 +4,10 @@ import FormControl from '@material-ui/core/FormControl';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
 import Switch from '@material-ui/core/Switch';
-import React from 'react';
+import { useState } from 'react';
 
 import CandidateSearch from './CandidateSearch';
+import CustomOrderMenu from './CustomOrderMenu';
 import styles from './Reviewer.module.css';
 import SingleCandidateReviewer from './SingleCandidateReviewer';
 import SingleCandidateViewer from './SingleCandidateViewer';
@@ -37,13 +38,32 @@ export default function ReviewApplicationPanel({
   onCommentChange,
   className,
 }: Props): JSX.Element {
-  const previous = () => updateCandidateId((id) => id - 1);
-  const next = () => updateCandidateId((id) => id + 1);
+  // const [selectIndex, setSelectIndex] = useState(0);
+  const defaultOrder = Array.from(Array(content.length).keys());
+  const [customOrder, setCustomOrder] = useState<number[]>([]);
+  const effectiveOrder = customOrder.length ? customOrder : defaultOrder;
 
+  const getIndex = (id: number) => {
+    return effectiveOrder.findIndex(num => num === id);
+  }
+
+  const previous = () => {
+    const index = getIndex(candidateId);
+    if(index >= 0) {
+      updateCandidateId(effectiveOrder[index - 1]);
+    }
+  }
+  const next = () => {
+    const index = getIndex(candidateId);
+    if(index >= 0) {
+      updateCandidateId(effectiveOrder[index + 1]);
+    }
+  }
   return (
     <div className={className}>
       <div className={styles.Section}>
         <CandidateSearch sheetData={{ header, content }} updateCandidateId={updateCandidateId} />
+        <CustomOrderMenu contentLength={content.length} setCustomOrder={setCustomOrder} />
         <div className={styles.Section}>
           <span>Candidate ID: </span>
           <FormControl>
@@ -53,7 +73,7 @@ export default function ReviewApplicationPanel({
               value={candidateId}
               onChange={(event) => updateCandidateId((event.target?.value ?? 0) as number)}
             >
-              {Array.from(Array(content.length).keys()).map((id) => (
+              {(customOrder.length ? customOrder : defaultOrder).map((id) => (
                 <MenuItem key={id} value={id}>
                   {id + 1}
                 </MenuItem>
@@ -62,10 +82,10 @@ export default function ReviewApplicationPanel({
           </FormControl>
           <span>of {content.length}.</span>
           <ButtonGroup color="primary" className={styles.Button}>
-            <Button disabled={candidateId === 0} onClick={previous}>
+            <Button disabled={getIndex(candidateId) === 0} onClick={previous}>
               Previous
             </Button>
-            <Button disabled={candidateId === content.length - 1} onClick={next}>
+            <Button disabled={getIndex(candidateId) === effectiveOrder.length - 1} onClick={next}>
               Next
             </Button>
           </ButtonGroup>


### PR DESCRIPTION
One way we attempted to avoid bias in the last recruiting semester was to review applicants in a random order, rather than in the order that is on the spreadsheet.
However, one annoying part of this was having to manually jump around to the shuffled indices that were assigned to you.

This diff solves this problem by allowing you define a custom order with a list of comma separated indices and navigate through it using the "next" and "previous" buttons.

Demo (all names shown are DTI members):
![image](https://i.imgur.com/wbOKPYH.gif)
